### PR TITLE
Update configuration handling to match other backend containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM python:3.8.12-slim-bullseye
 
 ARG with_models=false
-ARG models=
+ARG models
+
+ENV OVOS_CONFIG_BASE_FOLDER neon
+ENV OVOS_CONFIG_FILENAME diana.yaml
+ENV XDG_CONFIG_HOME /config
 
 WORKDIR /app
 

--- a/app/rmq.py
+++ b/app/rmq.py
@@ -31,7 +31,7 @@ class LibreMQ(MQConnector):
 
     def load_mq_config(self, config_path: str = "app/configs/config.json"):
         default_config_path = "app/configs/default_config.json"
-        if config_path:
+        if config_path is os.path.isfile(config_path):
             LOG.warning(f"Legacy configuration found at: {config_path}")
             with open(config_path) as config_file:
                 config = json.load(config_file)

--- a/app/rmq.py
+++ b/app/rmq.py
@@ -4,7 +4,7 @@ import os.path
 from flask import Flask
 from typing import Callable
 
-from neon_utils import LOG
+from ovos_utils.log import LOG
 from neon_mq_connector.connector import MQConnector
 from neon_mq_connector.utils.rabbit_utils import create_mq_callback
 from ovos_config.config import Configuration

--- a/app/rmq.py
+++ b/app/rmq.py
@@ -16,7 +16,7 @@ class LibreMQ(MQConnector):
 
     def __init__(self, app: Flask, translate_request: Callable):
         config = self.load_mq_config()
-        super().__init__(config = config, service_name = 'mq-libre-translate')
+        super().__init__(config=config, service_name='mq-libre-translate')
 
         self.app = app
         self.translate_request = translate_request
@@ -43,7 +43,7 @@ class LibreMQ(MQConnector):
             with open(default_config_path) as config_file:
                 config = json.load(config_file)
         LOG.info(f"Loaded MQ config")
-        return config
+        return config.get("MQ", config)
 
     @create_mq_callback(include_callback_props=('channel', 'method', 'body'))
     def handle_translate_request(self,

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ itsdangerous==2.1.2
 Werkzeug==2.1.2
 # Neon
 neon-mq-connector~=0.5
+ovos-config~=0.0.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,6 @@ argos-translate-files==1.0.5
 itsdangerous==2.1.2
 Werkzeug==2.1.2
 # Neon
-neon-mq-connector~=0.5
+neon-mq-connector~=0.7
 ovos-config~=0.0.10
+ovos-utils~=0.0.30


### PR DESCRIPTION
# Description
Updates configuration to use `ovos-config` with default ENVVARS set in Dockerfile to match other backend services

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->